### PR TITLE
feat($core): support transpile upper-cased PX

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,8 +71,10 @@ const handleIgnoreIdentifierRegx = (identifier, unit) => {
 export default postcss.plugin('postcss-plugin-px2rem', options => {
   const opts = { ...defaultOpts, ...options };
   let unit = 'px';
+  let units = [unit];
   if (isObject(opts.rootValue)) {
-    unit = Object.keys(opts.rootValue).join('|');
+    units = Object.keys(opts.rootValue);
+    unit = units.join('|');
   }
 
   const regText = `"[^"]+"|'[^']+'|url\\([^\\)]+\\)|(\\d*\\.?\\d+)(${unit})`;
@@ -92,8 +94,8 @@ export default postcss.plugin('postcss-plugin-px2rem', options => {
       const _decl = decl;
       // 1st check exclude
       if (opts.exclude && css.source.input.file && css.source.input.file.match(opts.exclude) !== null) return;
-      // 2st check 'px'
-      if (_decl.value.indexOf('px') === -1) return;
+      // 2st check units (px、PX、rpx)
+      if (!units.some(_unit => _decl.value.includes(_unit))) return;
       // 3nd check property black list
       if (blacklistedProp(opts.propBlackList, _decl.prop)) return;
       // 4rd check property white list

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -263,6 +263,26 @@ describe('rpx support', function () {
   });
 });
 
+describe('PX support', function () {
+  const sourceCSS = '.rule { font-size: 15PX }';
+
+  it('do not transpile PX by default', () => {
+    const expected = sourceCSS;
+    const processed = postcss(pxtorem()).process(sourceCSS).css;
+    expect(processed).toBe(expected);
+  });
+
+  it('transpile PX by passing rootValue', () => {
+    const expected = '.rule { font-size: 0.15rem }';
+    const processed = postcss(pxtorem({
+      rootValue: {
+        PX: 100,
+      },
+    })).process(sourceCSS).css;
+    expect(processed).toBe(expected);
+  });
+});
+
 describe('exclude support', () => {
   it('should work on the readme example', () => {
     const input = 'h1 { margin: 0 0 20px 20px; font-size: 32px; line-height: 1.2; letter-spacing: 1px; }';


### PR DESCRIPTION
## Summary

For now `PX` cannot be processed by this plugin, this Pull Request added general unit support.

